### PR TITLE
1、删除港前(legacy)—预约提柜

### DIFF
--- a/warehouse/templates/navbar.html
+++ b/warehouse/templates/navbar.html
@@ -22,12 +22,6 @@
                             <a href="{% url 'terminal_dispatch' %}?step=all" target="_blank">港口调度</a>
                             <a href="{% url 'contaier_pickup_status' %}?step=all" target="_blank">货柜状态追踪</a>
                             <a href="{% url 'contaier_pre_port_summary_dash' %}?step=all" target="_blank">货柜进度汇总</a>
-                            <div class="nested-dropdown" >
-                                <a>港前(legacy)</a>
-                                <div class="nested-dropdown-content">
-                                    <a href="{% url 'schedule_pickup' %}">预约提柜</a>
-                                </div>
-                            </div>
                         </div>
                     </div>
                 </li>

--- a/warehouse/views/pre_port/terminal_dispatch.py
+++ b/warehouse/views/pre_port/terminal_dispatch.py
@@ -171,8 +171,10 @@ class TerminalDispatch(View):
         )
         retrieval.actual_retrieval_timestamp = request.POST.get("actual_retrieval_timestamp")
         #填了实际提柜但是没有写预计提柜的，就默认预计提柜时间为实际提柜时间
-        retrieval.target_retrieval_timestamp_lower = request.POST.get("actual_retrieval_timestamp")
-        retrieval.target_retrieval_timestamp = request.POST.get("actual_retrieval_timestamp")
+        if not retrieval.target_retrieval_timestamp:
+            retrieval.target_retrieval_timestamp = request.POST.get("actual_retrieval_timestamp")
+        if not retrieval.target_retrieval_timestamp_lower:
+            retrieval.target_retrieval_timestamp_lower = request.POST.get("actual_retrieval_timestamp")
         today = datetime.now()  
         actual_ts = request.POST.get("actual_retrieval_timestamp")
         actual_ts = datetime.strptime(actual_ts, '%Y-%m-%dT%H:%M')


### PR DESCRIPTION
2、原港口调度处，填写实际提柜时会直接将实际提柜时间赋值给预计提柜时间，已改为没有填预计提柜时间时再赋值