### PR TITLE
1、pod每次上传之后，依旧保留之前筛选的仓库和送达时间；

### DIFF
--- a/warehouse/templates/post_port/shipment/05_2_delivery_and_pod.html
+++ b/warehouse/templates/post_port/shipment/05_2_delivery_and_pod.html
@@ -83,6 +83,8 @@
                         {{ upload_file_form.file }}
                         <input type="hidden" name="step" value="pod_upload">
                         <input type="hidden" name="shipment_batch_number" value="{{ f.shipment_batch_number }}">
+                        <input type="hidden" name="area" value="{{ area }}">
+                        <input type="hidden" name="arrived_at" value="{{ arrived_at }}">
                         <button type="submit" class="btn btn-success" style="font-size: 11px;">上传</button>
                     </td>
                 </tr>            

--- a/warehouse/views/po.py
+++ b/warehouse/views/po.py
@@ -177,15 +177,14 @@ class PO(View):
                     container = await sync_to_async(Container.objects.get)(container_number = bol)
                     query = models.Q(container_number=container)
                     if not pd.isnull(mark) and mark != '':
-                        if 'FFAU6134817' not in bol:
-                            query &= models.Q(shipping_mark=mark)
+                        query &= models.Q(shipping_mark=mark)
                     if not pd.isnull(fba) and fba != '':
                         query &= models.Q(fba_id=fba)
                     if not pd.isnull(ref) and ref != '':
                         query &= models.Q(ref_id=ref)
                     #try:
                     pochecketaseven = await sync_to_async(PoCheckEtaSeven.objects.get)(query)
-                    
+
                     cn = pytz.timezone('Asia/Shanghai')
                     current_time_cn = datetime.now(cn)
                     if "eta" in time_code:

--- a/warehouse/views/pre_port/order_creation.py
+++ b/warehouse/views/pre_port/order_creation.py
@@ -114,10 +114,10 @@ class OrderCreation(View):
         selected_orders = list(set(selected_orders))
         orders = await sync_to_async(list)(
                 Order.objects.select_related(
-                    "vessel_id", "container_number", "customer_name", "retrieval_id "
+                    "vessel_id", "container_number", "customer_name", "retrieval_id", "warehouse"
                 ).values(
                     "container_number__container_number", "customer_name__zem_code", "vessel_id__vessel_eta","vessel_id__vessel_etd", "cancel_time", "created_at",
-                    "retrieval_id__retrieval_carrier", "vessel_id__destination_port","vessel_id__master_bill_of_lading"
+                    "retrieval_id__retrieval_carrier", "vessel_id__destination_port","vessel_id__master_bill_of_lading","warehouse__name","container_number__container_type"
                 ).filter(
                     models.Q(container_number__container_number__in=selected_orders)
                 ) 
@@ -140,6 +140,7 @@ class OrderCreation(View):
                 "vessel_id__vessel_eta": "ETA",
                 "vessel_id__vessel_etd": "ETD",
                 "retrieval_id__retrieval_carrier": "carrier",
+                "container_number__container_type":"container_type"
             },
             axis=1
         )


### PR DESCRIPTION
2、订单列表导出预报时，增加仓库和柜型列