### PR TITLE
1、订单列表中是否取消列，改名为状态列，可以看到处于港前哪个进度，因为港后一个订单是分开处理的，所以状态只展示到已拆柜，港后进度在‘港后操…

### DIFF
--- a/warehouse/templates/order_management/order_list.html
+++ b/warehouse/templates/order_management/order_list.html
@@ -56,7 +56,7 @@
                         <th class="th" style="max-width: 2%; min-width: 10px; text-align: center;"></th>                   
                         <th class="th">客户</th>
                         <th class="th">柜号</th>
-                        <th class="th">取消预报</th>
+                        <th class="th">状态</th>
                         <th class="th" style="min-width: 110px;">入仓仓库</th>
                         <th class="th" style="min-width: 110px;">ETA</th>
                         <th class="th" style="min-width: 110px;">ETD</th>
@@ -102,11 +102,7 @@
                             </a>
                         </td>
                         <td class="td">
-                            {% if o.cancel_notification %}
-                                {{"已取消"}}
-                            {% else  %}
-                                {{"未取消"}}
-                            {% endif %}
+                            {{ o.status }}
                         </td>  
                         <td class="td">{{ o.warehouse }}</td>
                         <td class="td">

--- a/warehouse/views/pre_port/order_creation.py
+++ b/warehouse/views/pre_port/order_creation.py
@@ -304,6 +304,29 @@ class OrderCreation(View):
                 "warehouse",
             ).filter(criteria)
         )
+        #判断一下柜子的状态
+        for order in orders:
+            if order.cancel_notification:
+                status = "已取消"
+            elif not order.add_to_t49:
+                status = 'T49待追踪'
+            else:
+                if not order.retrieval_id.actual_retrieval_timestamp:
+                    if not order.retrieval_id.retrieval_carrier:
+                        status = "待预约提柜"
+                    else:
+                        status = "待确认提柜"
+                else:
+                    if not order.retrieval_id.arrive_at_destination:
+                        status = "待确认到仓"
+                    else:
+                        if not order.offload_id.offload_at:
+                            status = "确认拆柜"
+                        elif order.offload_id.offload_at:
+                            status = "已拆柜"
+                        else:
+                            status = "未知"
+            order.status =  status              
         context = {
             "orders": orders,
             "start_date_eta": start_date_eta,


### PR DESCRIPTION
…作’-‘表格导出’-‘报表导出’可以看到；

2、港后的报表导出中，当输入明确柜号或预约批次时，筛选条件就不考虑时间和仓库条件