### PR TITLE
81

### DIFF
--- a/warehouse/templates/navbar.html
+++ b/warehouse/templates/navbar.html
@@ -140,7 +140,7 @@
                                         <a>应收账单</a>
                                         <div class="nested-dropdown-content-l1">
                                             <a href="{% url 'accounting' %}?step=invoice_direct" target="_blank">整柜直送</a>
-                                            <a href="{% url 'accounting' %}?step=invoice_combina" target="_blank">组合柜</a>
+                                            <!--<a href="{% url 'accounting' %}?step=invoice_combina" target="_blank">组合柜</a>-->
                                             <div class="nested-dropdown-l2" >
                                                 <a>拆送</a>
                                                 <div class="nested-dropdown-content-l2">

--- a/warehouse/views/accounting.py
+++ b/warehouse/views/accounting.py
@@ -2740,6 +2740,12 @@ class Accounting(View):
                 or 0
             )
             invoice.receivable_delivery_amount = delivery_amount
+            #派送账单确认的时候，就计算一遍总费用
+            invoice.receivable_total_amount = (
+                float(invoice.receivable_preport_amount or 0)
+                + float(invoice.receivable_warehouse_amount or 0)
+                + float(invoice.receivable_delivery_amount or 0)
+            )
             invoice.save()
 
             order = Order.objects.select_related(


### PR DESCRIPTION
1、将应收账单里面的组合柜去掉，之前是用于组合柜确认的，现在组合柜和非组合柜的确认都合并到账单确认了，所以不用了
2、派送账单确认时，就计算一遍invoice的应收总收入