### PR TITLE
1

### DIFF
--- a/warehouse/views/pre_port/order_creation.py
+++ b/warehouse/views/pre_port/order_creation.py
@@ -1087,6 +1087,10 @@ class OrderCreation(View):
         price_display = defaultdict(set)
 
         for plts in plts_by_destination:
+            if 'UPS' in plts["destination"]:
+                #如果包含UPS，不需要显示细节，就显示UPS就可以了，张楠提
+                non_combina_dests.add('UPS')
+                continue
             dest = plts["destination"]
             dest = dest.replace("沃尔玛", "").split("-")[-1].strip()
             matched = False


### PR DESCRIPTION
订单清单，检查仓点时，如果有UPS的，就直接标注UPS，不用显示具体仓点名